### PR TITLE
修复乌兹别克斯坦区号233为998

### DIFF
--- a/countryData.json
+++ b/countryData.json
@@ -1110,7 +1110,7 @@
     "emoji": "🇺🇾"
   },
   {
-    "code": 233,
+    "code": 998,
     "tw": "烏茲別克",
     "en": "Uzbekistan",
     "locale": "UZ",


### PR DESCRIPTION
修改乌兹别克斯坦的区号(code)233为998，之前为233，和加纳重复了，233是加纳的区号，998才是乌兹别克斯坦的区号